### PR TITLE
Fix remote subscription query

### DIFF
--- a/src/v2/connectors/redisGraph.js
+++ b/src/v2/connectors/redisGraph.js
@@ -276,7 +276,7 @@ export default class RedisGraphConnector {
    */
   async runAppRemoteSubscriptionsQuery() {
     const whereClause = await this.createWhereClause([], ['app', 'sub']);
-    const query = `MATCH (app:Application)<-[{_interCluster:true}]-(sub:Subscription) ${whereClause === '' ? 'WHERE' : `(${whereClause}) AND`} exists(sub._hostingSubscription)=true RETURN app._uid, sub._uid, sub.status`;
+    const query = `MATCH (app:Application)<-[{_interCluster:true}]-(sub:Subscription) ${whereClause === '' ? 'WHERE' : `${whereClause} AND`} exists(sub._hostingSubscription)=true RETURN app._uid, sub._uid, sub.status`;
     return this.executeQuery({ query, removePrefix: false });
   }
 


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#<ISSUE_NUMBER>

**Description of Changes**

Remove invalid `()` in subscription query.

**Problem**
```
Syntax error at offset 69 near '('", locations: [{line: 9, column: 5}],…}
```