### PR TITLE
use namespaces in rbac caching instead of projects

### DIFF
--- a/src/v2/lib/__snapshots__/rbacCaching.test.js.snap
+++ b/src/v2/lib/__snapshots__/rbacCaching.test.js.snap
@@ -65,15 +65,15 @@ Object {
     Object {
       "metadata": Object {
         "annotations": Object {
-          "openshift.io/sa.scc.mcs": "s0:c16,c0",
-          "openshift.io/sa.scc.supplemental-groups": "1000240000/10000",
-          "openshift.io/sa.scc.uid-range": "1000240000/10000",
+          "openshift.io/sa.scc.mcs": "s0:c21,c0",
+          "openshift.io/sa.scc.supplemental-groups": "1000420000/10000",
+          "openshift.io/sa.scc.uid-range": "1000420000/10000",
         },
-        "creationTimestamp": "2020-02-09T04:09:15Z",
+        "creationTimestamp": "2020-06-26T17:44:03Z",
         "name": "default",
-        "resourceVersion": "69436",
-        "selfLink": "/apis/project.openshift.io/v1/projects/default",
-        "uid": "ef8d61de-4af1-11ea-969d-00000a10275c",
+        "resourceVersion": "8602",
+        "selfLink": "/api/v1/namespaces/default",
+        "uid": "27238466-2f13-4d61-bd10-b02567d72096",
       },
       "spec": Object {
         "finalizers": Array [

--- a/src/v2/lib/rbacCaching.js
+++ b/src/v2/lib/rbacCaching.js
@@ -37,7 +37,7 @@ export async function getClusterRbacConfig(kubeToken) {
       kubeConnector.get('/apis/rbac.authorization.k8s.io/v1/rolebindings'),
       kubeConnector.get('/apis/rbac.authorization.k8s.io/v1/clusterroles'),
       kubeConnector.get('/apis/rbac.authorization.k8s.io/v1/clusterrolebindings'),
-      kubeConnector.get('/apis/project.openshift.io/v1/projects'),
+      kubeConnector.get('/api/v1/namespaces'),
     ]);
     // Get just the items, whole response contians resourceVersion which changes everytime
     // check if we can just do resourceVersion

--- a/src/v2/mocks/kube.js
+++ b/src/v2/mocks/kube.js
@@ -15,7 +15,29 @@
 /* eslint-disable class-methods-use-this */
 export default class MockKubeConnector {
   async get(url) {
-    if (url === '/apis/authorization.openshift.io/v1') {
+    if (url.includes('/v1/namespaces')) {
+      return {
+        kind: 'NamespaceList',
+        apiVersion: 'v1',
+        metadata: { selfLink: '/api/v1/namespaces' },
+        items: [{
+          metadata: {
+            name: 'default',
+            selfLink: '/api/v1/namespaces/default',
+            uid: '27238466-2f13-4d61-bd10-b02567d72096',
+            resourceVersion: '8602',
+            creationTimestamp: '2020-06-26T17:44:03Z',
+            annotations: {
+              'openshift.io/sa.scc.mcs': 's0:c21,c0',
+              'openshift.io/sa.scc.supplemental-groups': '1000420000/10000',
+              'openshift.io/sa.scc.uid-range': '1000420000/10000',
+            },
+          },
+          spec: { finalizers: ['kubernetes'] },
+          status: { phase: 'Active' },
+        }],
+      };
+    } if (url === '/apis/authorization.openshift.io/v1') {
       // Get request for Openshift check
       return {
         kind: 'APIResourceList',


### PR DESCRIPTION
**Related Issue:**  https://github.com/open-cluster-management/search-chart/pull/33
**Also fixes** security vulnerability because docker image gets rebuilt.  https://github.com/open-cluster-management/backlog/issues/3119


**Description of Changes**

- [x] I wrote test cases to cover new code.