### PR TITLE
Fix incorrect RBAC for relationships

### DIFF
--- a/src/v2/connectors/redisGraph.js
+++ b/src/v2/connectors/redisGraph.js
@@ -233,7 +233,7 @@ export default class RedisGraphConnector {
         return `${alias}._rbac IN allowedResources OR ((exists(${alias}._hubClusterResource) AND (${alias}.namespace IN allowedNS)) OR (exists(${alias}._clusterNamespace) AND ${alias}._clusterNamespace IN allowedNS))`;
       }
       return `${alias}._rbac IN allowedResources`;
-    }).join(' OR ');
+    }).join(' AND ');
     const filterString = getFilterString(filters);
     if (filterString !== '') {
       whereClause = `WHERE ${filterString} AND (${whereClauseRbac})`;


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#4599

**Description of Changes**

When querying relationships, all parts of the query must pass the RBAC filter.