### PR TITLE
Fix keepalive configuration after lib updates

### DIFF
--- a/src/v2/lib/request.js
+++ b/src/v2/lib/request.js
@@ -31,7 +31,6 @@ function retryStrategy(err, response /* body, options */) {
 }
 
 const request = require('requestretry').defaults({
-  agent: httpsAgent, // This isn't working so setting above with https.globalAgent
   json: true,
   maxAttempts: 10,
   strictSSL: false,


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#5394

**Description of Changes**

After upgrading to the latest `requestretry` library, the keepalive agent isn't working correctly. This change sets the keepalive agent globally with `https.globalAgent` to avoid that problem.