### PR TITLE
Update the ua-parser-js dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9135,7 +9135,14 @@
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
+        "ua-parser-js": "^0.7.23"
+      },
+      "dependencies": {
+        "ua-parser-js": {
+          "version": "0.7.23",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+          "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
+        }
       }
     },
     "fbjs-css-vars": {
@@ -14940,11 +14947,6 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "ua-parser-js": {
-      "version": "0.7.22",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
     },
     "uid-safe": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cross-env": "^7.0.2",
     "express": "^4.17.1",
     "graphql": "^15.3.0",
-    "graphql-tools": "^7.0.0",
+    "graphql-tools": "^7.0.2",
     "graphql-type-json": "^0.3.2",
     "helmet": "^3.23.3",
     "lodash": "^4.17.20",


### PR DESCRIPTION
**Related Issues:**  
- open-cluster-management/backlog#5498
- https://github.com/open-cluster-management/backlog/issues/8131

**Description of Changes**
- Update graphql-tools dep to 7.0.2 (ua-parser-js is a required dependency of graphql-tools)