### PR TITLE
Exclude internal properties from keyword search

### DIFF
--- a/src/v2/models/search.js
+++ b/src/v2/models/search.js
@@ -51,7 +51,7 @@ function filterByKeywords(resultSet, keywords) {
    * which matches if the string contains all keywords and is case insensitive. */
   const regex = new RegExp(keywords.reduce((prev, curr) => `${prev}(?=.*${curr})`, ''), 'gi');
 
-  // Excludes properties starting with _
+  // Match the resource values, excluding internal properties starting with _
   return resultSet.filter((r) => Object.entries(r).find(([k, v]) => k.charAt(0) !== '_' && v.toString().match(regex)));
 }
 


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  open-cluster-management/backlog#17007

### Description of changes
- Exclude internal properties _rbac, _uid, and _hubClusterResource when searching for a keyword.

