### PR TITLE
Fix sanitize for search query operators

### DIFF
--- a/src/v2/models/search.js
+++ b/src/v2/models/search.js
@@ -17,7 +17,7 @@ import { checkSearchServiceStatus } from './searchServiceStatus';
 // Remove single and double quotes because these can be used to inject malicious
 // code in the RedisGraph query. (SQL injection).
 function sanitizeString(s) {
-  return s.replace(/[^a-zA-Z0-9\-_=./]/g, ''); // Less risk of injection, but could be missing valid chars.
+  return s.replace(/[^a-zA-Z0-9\-_!<>=./]/g, ''); // Less risk of injection, but could be missing valid chars.
 }
 
 // Sanitize all inputs to prevent "sql injection" attacks.


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

Fixes regex that removed operators: `!, <, >` from search queries