### PR TITLE
ACM-2800 Image property limit of 2500 items

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npm run start:production
 
 Name                    | Default | Description
 ---                     | ---     | ---
+defaultImageQueryLimit  | 2500    | Limits the images returned by the searchComplete query.
 defaultQueryLimit       | 10000   | Limits the resources returned by a search query.
 defaultQueryLoopLimit   | 5000    | Chunk size used by the keyword search logic.
 RBAC_POLL_INTERVAL      | 60000   | Interval at which we revalidate the RBAC cache.

--- a/config/config-defaults.json
+++ b/config/config-defaults.json
@@ -1,6 +1,7 @@
 {
   "API_SERVER_URL": "https://kubernetes.default.svc",
   "contextPath": "/searchapi",
+  "defaultImageQueryLimit": 2500,
   "defaultQueryLimit": 10000,
   "defaultQueryLoopLimit": 5000,
   "httpPort": 4010,

--- a/src/v2/connectors/redisGraph.js
+++ b/src/v2/connectors/redisGraph.js
@@ -598,7 +598,7 @@ export default class RedisGraphConnector {
         : `LIMIT ${limit}`;
       if (property === 'image') {
         // Max image limit of 2500 items, to many returned images causes UI to freeze.
-        limitClause = 'LIMIT 2500';
+        limitClause = `LIMIT ${config.get('defaultImageQueryLimit')}`;
       }
       let f = filters.length > 0 ? filters : [];
       f = filters.filter((filter) => filter.property);

--- a/src/v2/connectors/redisGraph.js
+++ b/src/v2/connectors/redisGraph.js
@@ -11,16 +11,16 @@
 // Copyright Contributors to the Open Cluster Management project
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable max-len */
-import _ from 'lodash';
-import fs from 'fs';
-import redis from 'redis';
 import dns from 'dns';
-import { Graph } from 'redisgraph.js';
+import fs from 'fs';
+import _ from 'lodash';
 import moment from 'moment';
+import redis from 'redis';
+import { Graph } from 'redisgraph.js';
 import config from '../../../config';
 import logger from '../lib/logger';
-import { isRequired } from '../lib/utils';
 import pollRbacCache, { getUserRbacFilter } from '../lib/rbacCaching';
+import { isRequired } from '../lib/utils';
 
 export function getPropertiesWithList() {
   return ['label', 'role', 'port', 'container', 'category', 'rules', 'addon', 'image'];
@@ -593,9 +593,13 @@ export default class RedisGraphConnector {
     let valuesList = [];
     if (this.rbac.length > 0) {
       const startTime = Date.now();
-      const limitClause = limit <= 0 || property === 'label'
+      let limitClause = limit <= 0 || property === 'label'
         ? ''
         : `LIMIT ${limit}`;
+      if (property === 'image') {
+        // Max image limit of 2500 items, to many returned images causes UI to freeze.
+        limitClause = 'LIMIT 2500';
+      }
       let f = filters.length > 0 ? filters : [];
       f = filters.filter((filter) => filter.property);
       const { withClause, whereClause } = await this.createWhereClause(f, ['n']);


### PR DESCRIPTION
**Related Issue:**  https://issues.redhat.com/browse/ACM-2800

### Description of changes

- searchComplete query should have a limit of 2500 items for image property.
